### PR TITLE
Update to modern paper_trail

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,15 +30,16 @@ widget = Widget.find 42
 widget.versions               # [<PaperTrail::Version>, <PaperTrail::Version>, ...]
 v = widget.versions.last
 ```
-Now you can also store object to `PaperTrail.whodunnit=`, and if object will be instance of `ActiveRecord::Base` it will store the global id in the version's `whodunnit` column.
+Now you can also store object to `PaperTrail.request.whodunnit=`, and if object will be instance of `ActiveRecord::Base` it will store the global id in the version's `whodunnit` column.
 
 And you can also retrieve the actually object later just by using method `actor`.
 
 ```ruby
 admin = Admin.find(1)                       # <Admin:0x007fa2df9a5590>
 
-PaperTrail.whodunnit = admin
-PaperTrail.actor                            # <Admin:0x007fa2df9a5590> actual object
+PaperTrail.request.whodunnit = admin
+PaperTrail.request.whodunnit                # "gid://app/Admin/1"
+PaperTrail.request.actor                    # <Admin:0x007fa2df9a5590> actual object
 
 widget.update_attributes :name => 'Wibble'
 widget.versions.last.whodunnit              # "gid://app/Admin/1"
@@ -48,8 +49,9 @@ widget.versions.last.actor                  # returns the actual object
 Method `actor` will return the whodunnit value if we pass value another than `ActiveRecord` object.
 
 ```ruby
-PaperTrail.whodunnit = 'admin_name'
-PaperTrail.actor                            # "admin_name"
+PaperTrail.request.whodunnit = 'admin_name'
+PaperTrail.request.whodunnit                # "admin_name"
+PaperTrail.request.actor                    # "admin_name"
 
 widget.update_attributes :name => 'Wibble'
 widget.versions.last.whodunnit              # "admin_name"

--- a/lib/paper_trail-globalid.rb
+++ b/lib/paper_trail-globalid.rb
@@ -2,16 +2,16 @@ require "paper_trail_globalid/paper_trail"
 require "paper_trail_globalid/version"
 require "paper_trail_globalid/version_concern"
 
-module PaperTrailGlobalid
-  module ::PaperTrail
+module ::PaperTrail
+  module Request
     class << self
-      prepend ::PaperTrailGlobalid::PaperTrail
+      prepend ::PaperTrailGlobalid::Request
     end
   end
+end
 
-  module ::PaperTrail
-    module VersionConcern
-      include ::PaperTrailGlobalid::VersionConcern
-    end
+module ::PaperTrail
+  module VersionConcern
+    include ::PaperTrailGlobalid::VersionConcern
   end
 end

--- a/lib/paper_trail_globalid/paper_trail.rb
+++ b/lib/paper_trail_globalid/paper_trail.rb
@@ -1,15 +1,15 @@
 module PaperTrailGlobalid
-  module PaperTrail
+  module Request
     def whodunnit=(value)
       if value.is_a? ActiveRecord::Base
-        paper_trail_store[:whodunnit] = value.to_gid
+        super(value.to_gid)
       else
-        paper_trail_store[:whodunnit] = value
+        super(value)
       end
     end
 
     def actor
-      ::GlobalID::Locator.locate(paper_trail_store[:whodunnit]) || whodunnit
+      ::GlobalID::Locator.locate(store[:whodunnit]) || whodunnit
     end
   end
 end

--- a/lib/paper_trail_globalid/version.rb
+++ b/lib/paper_trail_globalid/version.rb
@@ -1,3 +1,3 @@
 module PaperTrailGlobalid
-  VERSION = "0.2.0"
+  VERSION = "0.3.0"
 end

--- a/paper_trail_globalid.gemspec
+++ b/paper_trail_globalid.gemspec
@@ -18,16 +18,16 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'paper_trail', '>= 3.0.0'
-  spec.add_dependency 'globalid'
+  spec.add_dependency "paper_trail", ">= 9.0.0"
+  spec.add_dependency "globalid"
 
-  spec.add_development_dependency 'appraisal', '~> 2.1'
-  spec.add_development_dependency "bundler", "~> 1.6"
+  spec.add_development_dependency "appraisal", "~> 2.1"
+  spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.3.0"
   spec.add_development_dependency "coveralls", "~> 0.8.2"
-  spec.add_development_dependency "activerecord", ">=3.2.0"
-  spec.add_development_dependency "activesupport", ">=3.2.0"
+  spec.add_development_dependency "activerecord", ">= 3.2.0"
+  spec.add_development_dependency "activesupport", ">= 3.2.0"
   spec.add_development_dependency "sqlite3"
   spec.add_development_dependency "byebug"
 end

--- a/spec/paper_trail_globalid_spec.rb
+++ b/spec/paper_trail_globalid_spec.rb
@@ -16,7 +16,7 @@ describe PaperTrailGlobalid do
         t.string :name
       end
 
-      create_table :versions do |t|
+      create_table :versions, force: true do |t|
         t.string   :item_type, :null => false
         t.integer  :item_id,   :null => false
         t.string   :event,     :null => false
@@ -30,6 +30,7 @@ describe PaperTrailGlobalid do
   after(:all) do
     ActiveRecord::Schema.define do
       drop_table :orders
+      drop_table :admins
       drop_table :versions
     end
     ActiveRecord::Migration.verbose = true
@@ -43,20 +44,20 @@ describe PaperTrailGlobalid do
       @version = @order.versions.last
     end
 
-    describe 'paper_trail' do
+    describe 'request' do
       describe 'class_methods' do
-        describe 'PaperTrail.actor' do
+        describe '.actor' do
           context 'when value for whodunnit is object of ActiveRecord' do
             it 'returns object' do
-              PaperTrail.whodunnit=@admin
-              expect(PaperTrail.actor).to eq(@admin)
+              PaperTrail.request.whodunnit=@admin
+              expect(PaperTrail.request.actor).to eq(@admin)
             end
           end
 
           context 'when value for whodunnit is not an object of ActiveRecord' do
             it 'returns value itself' do
-              PaperTrail.whodunnit="test"
-              expect(PaperTrail.actor).to eq("test")
+              PaperTrail.request.whodunnit="test"
+              expect(PaperTrail.request.actor).to eq("test")
             end
           end
         end
@@ -64,15 +65,15 @@ describe PaperTrailGlobalid do
         describe '.whodunnit' do
           context 'when value for whodunnit is object of ActiveRecord' do
             it 'returns global id' do
-              PaperTrail.whodunnit=@admin
-              expect(PaperTrail.paper_trail_store[:whodunnit]).to eq(@admin.to_gid)
+              PaperTrail.request.whodunnit=@admin
+              expect(PaperTrail.request.whodunnit).to eq(@admin.to_gid)
             end
           end
 
           context 'when value for whodunnit is not an object of ActiveRecord' do
             it 'returns value itself' do
-              PaperTrail.whodunnit="test"
-              expect(PaperTrail.paper_trail_store[:whodunnit]).to eq("test")
+              PaperTrail.request.whodunnit="test"
+              expect(PaperTrail.request.whodunnit).to eq("test")
             end
           end
         end


### PR DESCRIPTION
### Motivation / Background

Fixes #11

This Pull Request has been created to update paper_trail-globalid to fully work with changes introducted in paper_trail 9.0.0.

It has been tested with every major version of paper_trail up to and including 16 (the current version), with various ruby versions (2.7.7, 3.3.4, 3.4.1), and various versions of activesupport / activerecord.

### Detail

This Pull Request changes the implementation so that we overwrite the `#whodunnit=` method on `::PaperTrail::Request` instead of adding the method to `::PaperTrail` where it no longer lives.

After conditianlly changing the value of the update to the gid, it now uses `super` (the original method from ::PaperTrail::Request`) to set the whodunnit field instead of attempting to write directly to the store.

The `#actor` method is still added, but now to `::PaperTrail::Request` where it makes the most sense. It uses the store value to attempt to load an object with a gid, but falls back to the standard `#whodunnit` that is available in `::PaperTrail::Request` since 9.0.0.

### Additional information

- Not only has `#paper_trail_store` moved from `::PaperTrail` to `::PaperTrail::Request`, it has also moved name to `#store`.
- Removed `module ::PaperTrail` when prepending and including paper_trail-globalid modules to paper_trail as this was not required.
- Changed the occasional `'` to a `"` and added the occasional white space to make files more consistent.
- Updated the database table creation/destruction code so it is more consistent.
